### PR TITLE
Update AnatomyOfMatplotlib-Part1-Figures_Subplots_and_layouts.ipynb

### DIFF
--- a/AnatomyOfMatplotlib-Part1-Figures_Subplots_and_layouts.ipynb
+++ b/AnatomyOfMatplotlib-Part1-Figures_Subplots_and_layouts.ipynb
@@ -58,7 +58,7 @@
     "[Matplotlib](https://github.com/matplotlib) is hosted by GitHub.\n",
     "\n",
     "### Bug Reports and feature requests\n",
-    "So, you think you found a bug? Or maybe you think some feature is just too difficult to use? Or missing altogether? Submit your bug reports [here](https://github.com/matplotlib/matplotlib/issues) at Matplotlib's issue tracker. We even have a process for submitting and discussing Matplotlib Enhancement Proposals ([MEPs](https://matplotlib.org/devel/MEP/index.html))."
+    "So, you think you found a bug? Or maybe you think some feature is just too difficult to use? Or missing altogether? Submit your bug reports [here](https://github.com/matplotlib/matplotlib/issues) at Matplotlib's issue tracker. We even have a process for submitting and discussing Matplotlib Enhancement Proposals ([MEPs](https://matplotlib.org/stable/devel/MEP/index.html))."
    ]
   },
   {


### PR DESCRIPTION
replaced https://matplotlib.org/devel/MEP/index.html with https://matplotlib.org/stable/devel/MEP/index.html